### PR TITLE
Add missing preference for IndexSuspenderInterface

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -22,6 +22,9 @@
     <!-- Add modules functionality to indexer:reindex command -->
     <preference for="Magento\Indexer\Console\Command\IndexerReindexCommand" type="TechDivision\IndexSuspender\Console\IndexerReindexCommand"/>
 
+    <preference for="TechDivision\IndexSuspender\Api\IndexSuspenderInterface"
+                type="TechDivision\IndexSuspender\Model\DeltaIndexSuspender"/>
+
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
This fixes #3 

For Magento DI to be able to inject an Interface, there must be a preference for the implementing class set.