### PR TITLE
Mark as compatible with Magento 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "techdivision/indexsuspender",
   "description": "Allows to suspend regular indexing processes during a specific task.",
   "require": {
-    "magento/framework": "100.1.*"
+    "magento/framework": "100.1.*|103.0.*"
   },
   "type": "magento2-module",
   "autoload": {


### PR DESCRIPTION
Relates to #2 

I've installed and used this extension in a Magento 2.4.2-p2 without problems.

There are some deprecation warnings, but as far as I can see, this module is compatible with Magento 2.4