### PR TITLE
Don't create DeltaIndexSuspender inside constructor as there might be no db connection

### DIFF
--- a/Console/IndexerReindexCommand.php
+++ b/Console/IndexerReindexCommand.php
@@ -29,8 +29,11 @@ use TechDivision\IndexSuspender\Model\DeltaIndexSuspenderFactory;
  */
 class IndexerReindexCommand extends CoreIndexerReindexCommand
 {
-    /** @var  DeltaIndexSuspender */
-    private $deltaIndexSuspender;
+    /** @var DeltaIndexSuspenderFactory */
+    private $deltaIndexSuspenderFactory;
+
+    /** @var ?DeltaIndexSuspender */
+    private $deltaIndexSuspender = null;
 
     /**
      * @param ObjectManagerFactory $objectManagerFactory
@@ -41,7 +44,7 @@ class IndexerReindexCommand extends CoreIndexerReindexCommand
         DeltaIndexSuspenderFactory $deltaIndexSuspenderFactory
     ) {
         parent::__construct($objectManagerFactory);
-        $this->deltaIndexSuspender = $deltaIndexSuspenderFactory->create();
+        $this->deltaIndexSuspenderFactory = $deltaIndexSuspenderFactory;
     }
 
     /**
@@ -49,6 +52,10 @@ class IndexerReindexCommand extends CoreIndexerReindexCommand
      */
     public function getDeltaIndexSuspender()
     {
+        if ($this->deltaIndexSuspender === null) {
+            $this->deltaIndexSuspender = $this->deltaIndexSuspenderFactory->create();
+        }
+
         return $this->deltaIndexSuspender;
     }
 
@@ -61,9 +68,10 @@ class IndexerReindexCommand extends CoreIndexerReindexCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->deltaIndexSuspender->suspend();
+        $deltaIndexSuspender = $this->getDeltaIndexSuspender();
+        $deltaIndexSuspender->suspend();
         $returnCode = parent::execute($input, $output);
-        $this->deltaIndexSuspender->resume();
+        $deltaIndexSuspender->resume();
 
         return $returnCode;
     }


### PR DESCRIPTION
This should fix #6 

The creation of DeltaIndexSuspender includes the initialization of an AbstractCollection, which requires a DB connection. 

This is both a performance issue, as the command might be initialized, but not executed.

Also, this leads to a crash of the CLI application if it is run in an environment without a DB connection configured.